### PR TITLE
Fix outdated v2.0 references and documentation drift

### DIFF
--- a/.claude/skills/braindump/SKILL.md
+++ b/.claude/skills/braindump/SKILL.md
@@ -101,7 +101,6 @@ Create braindump file with this structure:
 ```markdown
 ---
 type: "braindump"
-analyst: "brain-dump-analyst"
 domain: "[personal|professional|project-specific|mixed]"
 project: "[project-name]" # Only if project-specific
 date: "YYYY-MM-DD"

--- a/.claude/skills/daily-brief/SKILL.md
+++ b/.claude/skills/daily-brief/SKILL.md
@@ -124,7 +124,6 @@ Create structured briefing document:
 ```markdown
 ---
 type: "daily-brief"
-curator: "news-curator"
 domain: "shared"
 date: "YYYY-MM-DD"
 created: "YYYY-MM-DD HH:MM"

--- a/.github/MARKETPLACE.md
+++ b/.github/MARKETPLACE.md
@@ -29,16 +29,13 @@ The `plugin.json` file contains:
 
 ### Components
 
-#### Commands (5 total)
-1. `/onboarding` - Personalization workflow
-2. `/daily-brief` - News intelligence
-3. `/braindump` - Thought capture
-4. `/weekly-checkin` - Pattern analysis
-5. `/knowledge-consolidation` - Framework building
-
-#### Agents (2 total)
-1. `brain-dump-analyst` - Stream-of-consciousness analysis
-2. `news-curator` - Verified news curation
+#### Skills (6 total)
+1. `onboarding` - Personalization workflow
+2. `daily-brief` - News intelligence
+3. `braindump` - Thought capture
+4. `weekly-checkin` - Pattern analysis
+5. `knowledge-consolidation` - Framework building
+6. `url-dump` - Quick URL capture with auto-extraction
 
 ### Extended Metadata
 - `features`: List of key COG features
@@ -112,16 +109,15 @@ To validate your plugin manifest:
 
 ```bash
 # Check JSON syntax
-cat plugin.json | python3 -m json.tool > /dev/null && echo "✓ JSON is valid"
+cat .claude-plugin/plugin.json | python3 -m json.tool > /dev/null && echo "✓ JSON is valid"
 
-# Verify all file paths exist
-ls .claude/commands/onboarding.md
-ls .claude/commands/daily-brief.md
-ls .claude/commands/braindump.md
-ls .claude/commands/weekly-checkin.md
-ls .claude/commands/knowledge-consolidation.md
-ls .claude/subagents/brain-dump-analyst.md
-ls .claude/subagents/news-curator.md
+# Verify all skill files exist
+ls .claude/skills/onboarding/SKILL.md
+ls .claude/skills/daily-brief/SKILL.md
+ls .claude/skills/braindump/SKILL.md
+ls .claude/skills/weekly-checkin/SKILL.md
+ls .claude/skills/knowledge-consolidation/SKILL.md
+ls .claude/skills/url-dump/SKILL.md
 ```
 
 All paths should exist relative to the repository root.


### PR DESCRIPTION
- Remove orphaned subagent references from braindump and daily-brief SKILL.md templates (brain-dump-analyst, news-curator no longer exist in v3.0)
- Update MARKETPLACE.md to reference skills instead of deprecated commands
- Fix validation paths to use .claude/skills/*/SKILL.md structure
- Add url-dump skill to components list

https://claude.ai/code/session_01NmsFQgsyr1eb8V4o8oHuFs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/huytieu/cog-second-brain/pull/4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
