### PR TITLE
Fix hallucinated timestamps in content-generating skills

### DIFF
--- a/.claude/skills/braindump/SKILL.md
+++ b/.claude/skills/braindump/SKILL.md
@@ -39,6 +39,12 @@ Transform raw thoughts into strategic intelligence through quick capture, system
    - Use user's name for friendly communication
    - Read `03-professional/COMPETITIVE-WATCHLIST.md` if it exists for competitive intelligence detection
 
+**Get current timestamp (REQUIRED before generating any files):**
+
+1. Run `date '+%Y-%m-%d %H:%M'` using Bash to get the actual current date and time
+2. Store this value and use it for ALL timestamp fields (`created:` frontmatter AND filename `HHMM` component)
+3. NEVER guess or fabricate the time — always use the value returned by the `date` command
+
 ## Process Flow
 
 ### 1. User Interaction & Input Collection

--- a/.claude/skills/daily-brief/SKILL.md
+++ b/.claude/skills/daily-brief/SKILL.md
@@ -40,6 +40,12 @@ Find verified, relevant news for personalized daily briefings with strict verifi
    - Use topics to curate relevant news
    - Connect news to user's active projects when relevant
 
+**Get current timestamp (REQUIRED before generating any files):**
+
+1. Run `date '+%Y-%m-%d %H:%M'` using Bash to get the actual current date and time
+2. Store this value and use it for the `created:` frontmatter field
+3. NEVER guess or fabricate the time — always use the value returned by the `date` command
+
 ## Process Flow
 
 ### 1. Gather Context

--- a/.claude/skills/knowledge-consolidation/SKILL.md
+++ b/.claude/skills/knowledge-consolidation/SKILL.md
@@ -21,6 +21,14 @@ Transform scattered insights from braindumps, daily briefs, and check-ins into c
 - If `agent_mode: team` — delegate scanning and pattern extraction to parallel sub-agents (e.g., one per domain: personal braindumps, professional braindumps, project-specific content, daily briefs). Each agent identifies themes and patterns, then a synthesis agent combines findings into frameworks.
 - If `agent_mode: solo` (default) — handle all scanning, pattern recognition, and framework building directly. No delegation.
 
+## Pre-Flight Check
+
+**Get current timestamp (REQUIRED before generating any files):**
+
+1. Run `date '+%Y-%m-%d %H:%M'` using Bash to get the actual current date and time
+2. Store this value and use it for the `created:` frontmatter field
+3. NEVER guess or fabricate the time — always use the value returned by the `date` command
+
 ## Process Flow
 
 ### 1. Data Gathering

--- a/.claude/skills/weekly-checkin/SKILL.md
+++ b/.claude/skills/weekly-checkin/SKILL.md
@@ -30,6 +30,12 @@ Comprehensive weekly review and analysis integrating insights across all domains
    - Read active projects to review project-specific progress
    - Tailor reflection questions to user's role and projects
 
+**Get current timestamp (REQUIRED before generating any files):**
+
+1. Run `date '+%Y-%m-%d %H:%M'` using Bash to get the actual current date and time
+2. Store this value and use it for the `created:` frontmatter field
+3. NEVER guess or fabricate the time — always use the value returned by the `date` command
+
 ## Process Flow
 
 ### 1. Gather Context


### PR DESCRIPTION
Skills that produce files with `created:` frontmatter timestamps (braindump, daily-brief, weekly-checkin, knowledge-consolidation) had no mechanism to obtain the actual current time. Claude receives the current date via system prompt but not the time, resulting in fabricated HH:MM values — observed deltas ranged from 25 minutes to 7 hours off.

Added a pre-flight step to each affected skill instructing the agent to run `date '+%Y-%m-%d %H:%M'` before generating files, consistent with the pattern already used by the save skill's git commit command.

Affected skills:
- braindump (frontmatter + filename HHMM component)
- daily-brief (frontmatter)
- weekly-checkin (frontmatter)
- knowledge-consolidation (frontmatter)