### PR TITLE
Add story deduplication to daily brief skill

### DIFF
--- a/.claude/skills/daily-brief/SKILL.md
+++ b/.claude/skills/daily-brief/SKILL.md
@@ -68,10 +68,14 @@ Collect the information needed for personalized curation:
 
 #### Deduplication — Previous Brief Scan
 
-Read the last 3 daily briefs from `01-daily/briefs/` (most recent first):
-- Extract `dedup_slugs` from their frontmatter (if present)
-- Also scan their headlines/story titles as fallback
+Read up to 3 most recent daily briefs from `01-daily/briefs/` (most recent first):
+- Extract `dedup_urls` from their frontmatter (if present)
+- Also scan their headlines/story titles as semantic fallback for cross-source matching
 - Build a set of **covered stories** to avoid repeating
+
+**Matching rules (in priority order):**
+1. **URL match (primary):** If a candidate story's main source URL already appears in `dedup_urls`, it's a known story
+2. **Headline match (fallback):** If the URL is different but the headline describes the same event as a previous story, treat as duplicate — this catches the same story reported by different outlets
 
 During news research (Step 2), apply dedup rules:
 - **Skip** stories already covered unless there is a **material update** (new data, resolution, escalation, reversal)
@@ -160,7 +164,7 @@ tags: ["#daily-brief", "#news", "#strategic-intelligence"]
 interests: ["interest1", "interest2"]
 projects_referenced: ["project1"]
 items_count: [number]
-dedup_slugs: ["slug-of-each-story-covered"]
+dedup_urls: ["https://primary-source-url-for-each-story-covered"]
 ---
 
 # Daily Brief - [Date]

--- a/.claude/skills/daily-brief/SKILL.md
+++ b/.claude/skills/daily-brief/SKILL.md
@@ -66,6 +66,18 @@ Collect the information needed for personalized curation:
 - Read `03-professional/COMPETITIVE-WATCHLIST.md` (if exists) for:
   - Companies/people to track
 
+#### Deduplication — Previous Brief Scan
+
+Read the last 3 daily briefs from `01-daily/briefs/` (most recent first):
+- Extract `dedup_slugs` from their frontmatter (if present)
+- Also scan their headlines/story titles as fallback
+- Build a set of **covered stories** to avoid repeating
+
+During news research (Step 2), apply dedup rules:
+- **Skip** stories already covered unless there is a **material update** (new data, resolution, escalation, reversal)
+- If including an update, prefix with "**Update:** _first covered [date]_"
+- Stories older than 3 briefs are eligible for re-inclusion if still developing
+
 ### 2. News Research and Curation
 
 Apply comprehensive news research methodology:
@@ -148,6 +160,7 @@ tags: ["#daily-brief", "#news", "#strategic-intelligence"]
 interests: ["interest1", "interest2"]
 projects_referenced: ["project1"]
 items_count: [number]
+dedup_slugs: ["slug-of-each-story-covered"]
 ---
 
 # Daily Brief - [Date]


### PR DESCRIPTION
Quite often, the `/daily-brief` skill **repeats** stories from **previous days**.

Briefs now scan the last 3 daily briefs during pre-flight to build a set of covered stories. Repeated stories are **skipped** unless there's a material update (new data, resolution, escalation), in which case they're prefixed with "Update:". New `dedup_urls` frontmatter field enables fast extraction by future briefs.