### PR TITLE
fix: restore the star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Built with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com/),
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=huytieu/COG-second-brain&type=date&legend=top-left)](https://www.star-history.com/#huytieu/COG-second-brain&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=huytieu/COG-second-brain&type=date&legend=top-left)](https://star-history.dera.page/#huytieu/COG-second-brain&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken. The upstream
service it relied on no longer works reliably because of GitHub's
stargazer API restrictions, so the chart renders as a dead image.

This PR switches the chart to star-history.dera.page, a token-free fork
that serves the chart from another data source. The fix only touches the
star history section; the badge and the rest of the README are unchanged.

Repositories like JavaGuide and dify already use this alternative
successfully, and this restores a live, up-to-date star history chart.