### PR TITLE
fix: remove two dead links from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ graph LR
     D --> F[iCloud]
 ```
 
-> **New to COG?** Watch the [2-minute walkthrough](https://youtube.com/PLACEHOLDER) to see it in action.
-
 ## Quick Start
 
 **1. Clone & enter the repo:**
@@ -327,10 +325,6 @@ Built with [Claude Code](https://claude.ai/code), [Cursor](https://cursor.com/),
 - **Zettelkasten** — atomic, interlinked notes as the foundation of knowledge
 - **Building a Second Brain (Tiago Forte)** — PARA organization, progressive summarization
 - **GTD (David Allen)** — capture everything, process systematically
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=huytieu/COG-second-brain&type=date&legend=top-left)](https://www.star-history.com/#huytieu/COG-second-brain&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
Both links in the README's opening and closing sections are broken. This removes them.

### 1. The "2-minute walkthrough" placeholder — `README.md:25`

```
> **New to COG?** Watch the [2-minute walkthrough](https://youtube.com/PLACEHOLDER) to see it in action.
```

Still `PLACEHOLDER` on `main` at v3.10.0, and it survived both post-v3.9 README commits (`b852369`, `4c9c1eb`). It is the only YouTube reference anywhere in `README.md`, `SETUP.md`, or `docs/`, so there is no owner-recorded walkthrough to point it at.

Removed rather than substituted. A dead link is bad; quietly sending new users to an unaffiliated third party's video would be worse.

### 2. The Star History chart — `README.md:332`

The embed renders an error card, not a chart. Verified by following the redirect and extracting the SVG text nodes:

- `api.star-history.com` → HTTP 200 `image/svg+xml`, but the payload contains `GitHub restricted access to star data` / `GitHub team is looking into it` (1 path, 0 data points).

star-history.com's own blog post of 2026-07-06 confirms GitHub restricted the stargazers API on 2026-06-30 and that embedded README charts are broken for essentially every repository.

Removed the broken embed rather than repointing it at an unofficial mirror. If the chart comes back it should be via star-history's documented token-embed route (a scoped token for a repo you own, encrypted, safe in a public README) or a committed static snapshot — not a third-party host with standing ability to change what this README displays.

### Verification

```
./scripts/validate-agent-surface.sh   # exit 0, 0 warnings
grep -n "PLACEHOLDER\|star-history" README.md   # no matches
```

No packaging surface, skill, agent, or version file is touched.

Closes #18