### PR TITLE
docs: correct what update-cog's customization check actually compares

### DIFF
--- a/.claude/skills/update-cog/SKILL.md
+++ b/.claude/skills/update-cog/SKILL.md
@@ -59,11 +59,14 @@ git diff HEAD..cog-upstream/main -- <file>
 ### 5. Detect Customizations
 Before updating, check if the user has customized any framework files:
 ```bash
-# Compare user's file against the version they originally got
+# Show how the working tree differs from current upstream HEAD.
+# NOTE: this cannot tell a local customization apart from an upstream
+# change you have not pulled yet — both show up as a diff. Treat any
+# output as "needs a look", not as proof the user edited the file.
 git diff cog-upstream/main -- <file>
 ```
 
-If a file has local customizations, warn the user and offer options:
+If a file differs, warn the user and offer options:
 - **Keep yours**: Skip this file
 - **Use upstream**: Overwrite with the new version
 - **Backup + update**: Save current as `<file>.backup-YYYYMMDD` then update

--- a/skills/update-cog/SKILL.md
+++ b/skills/update-cog/SKILL.md
@@ -59,11 +59,14 @@ git diff HEAD..cog-upstream/main -- <file>
 ### 5. Detect Customizations
 Before updating, check if the user has customized any framework files:
 ```bash
-# Compare user's file against the version they originally got
+# Show how the working tree differs from current upstream HEAD.
+# NOTE: this cannot tell a local customization apart from an upstream
+# change you have not pulled yet — both show up as a diff. Treat any
+# output as "needs a look", not as proof the user edited the file.
 git diff cog-upstream/main -- <file>
 ```
 
-If a file has local customizations, warn the user and offer options:
+If a file differs, warn the user and offer options:
 - **Keep yours**: Skip this file
 - **Use upstream**: Overwrite with the new version
 - **Backup + update**: Save current as `<file>.backup-YYYYMMDD` then update


### PR DESCRIPTION
Closing #17 surfaced two findings from the automated review that had been sitting on it since April. I said I'd check whether either still applies to `main`. One does.

### The real one

`.claude/skills/update-cog/SKILL.md` § Detect Customizations:

```bash
# Compare user's file against the version they originally got
git diff cog-upstream/main -- <file>
```

It does not do that. `git diff cog-upstream/main -- <file>` compares the **working tree against current upstream HEAD**, so an upstream change the user hasn't pulled yet is indistinguishable from a local customization — both just show up as a diff. The step then presents "Keep yours / Use upstream / Backup + update" on the strength of that reading, which means a user can be told they customized a file they never touched.

Rewritten to say what the command actually does and to frame its output as "needs a look" rather than "the user edited this". No behavior change to the updater itself — this is the skill's guidance to the agent running it.

### The one that does not apply

The same review flagged `daily-brief`'s generated-document template losing its `---` frontmatter delimiters. Checked: the delimiters are intact on `main` (`.claude/skills/daily-brief/SKILL.md:155`). That defect was introduced by PR #17's own frontmatter conversion, not present here. Nothing to fix.

### Verification

```
./scripts/build-agent-plugin.sh && ./scripts/validate-agent-surface.sh   # exit 0, 0 warnings
```

Edited `.claude/skills/` only; `skills/` regenerated. No version bump — this is a comment correction and `cog-update.sh` delivers on content diff, not version gate.